### PR TITLE
Support server passphrase provided by ENV

### DIFF
--- a/c2FmZQ/c2FmZQ-client/internal/cli.go
+++ b/c2FmZQ/c2FmZQ-client/internal/cli.go
@@ -33,6 +33,7 @@ type App struct {
 	flagLogLevel       int
 	flagPassphraseFile string
 	flagPassphraseCmd  string
+	flagPassphraseEnv  string
 	flagAPIServer      string
 	flagAutoUpdate     bool
 }
@@ -85,6 +86,13 @@ func New() *App {
 			Usage:       "Read the database passphrase from `FILE`.",
 			EnvVars:     []string{"C2FMZQ_PASSPHRASE_FILE"},
 			Destination: &app.flagPassphraseFile,
+		},
+		&cli.StringFlag{
+			Name:        "passphrase-env",
+			Value:       "",
+			Usage:       "Use value of `ENV` as database passphrase.",
+			EnvVars:     []string{"C2FMZQ_PASSPHRASE_ENV"},
+			Destination: &app.flagPassphraseEnv,
 		},
 		&cli.StringFlag{
 			Name:        "server",
@@ -457,7 +465,7 @@ func (a *App) Run(args []string) error {
 func (a *App) init(ctx *cli.Context, update bool) error {
 	if a.client == nil {
 		log.Level = a.flagLogLevel
-		pp, err := crypto.Passphrase(a.flagPassphraseCmd, a.flagPassphraseFile)
+		pp, err := crypto.Passphrase(a.flagPassphraseCmd, a.flagPassphraseFile, a.flagPassphraseEnv)
 		if err != nil {
 			return err
 		}

--- a/c2FmZQ/c2FmZQ-server/inspect/main.go
+++ b/c2FmZQ/c2FmZQ-server/inspect/main.go
@@ -33,6 +33,7 @@ var (
 	flagEncryptMetadata bool
 	flagPassphraseFile  string
 	flagPassphraseCmd   string
+	flagPassphraseEnv   string
 )
 
 func main() {
@@ -81,6 +82,13 @@ func main() {
 				Usage:       "Read the database passphrase from `FILE`.",
 				EnvVars:     []string{"C2FMZQ_PASSPHRASE_FILE"},
 				Destination: &flagPassphraseFile,
+			},
+			&cli.StringFlag{
+				Name:        "passphrase-env",
+				Value:       "",
+				Usage:       "Use value of `ENV` as database passphrase.",
+				EnvVars:     []string{"C2FMZQ_PASSPHRASE_ENV"},
+				Destination: &flagPassphraseEnv,
 			},
 		},
 		Commands: []*cli.Command{
@@ -200,6 +208,11 @@ func main() {
 						Value: "",
 						Usage: "Read the new database passphrase from `FILE`.",
 					},
+					&cli.StringFlag{
+						Name:  "new-passphrase-env",
+						Value: "",
+						Usage: "Change database passphrase to value of `ENV`.",
+					},
 				},
 			},
 			&cli.Command{
@@ -294,7 +307,7 @@ func initDB(c *cli.Context) (*database.Database, error) {
 	var pp []byte
 	if flagEncryptMetadata {
 		var err error
-		if pp, err = crypto.Passphrase(flagPassphraseCmd, flagPassphraseFile); err != nil {
+		if pp, err = crypto.Passphrase(flagPassphraseCmd, flagPassphraseFile, flagPassphraseEnv); err != nil {
 			return nil, err
 		}
 	}
@@ -361,7 +374,7 @@ func changeMasterKey(c *cli.Context) error {
 	log.Level = flagLogLevel
 	log.Infof("Working on %s", flagDatabase)
 
-	pp, err := crypto.Passphrase(flagPassphraseCmd, flagPassphraseFile)
+	pp, err := crypto.Passphrase(flagPassphraseCmd, flagPassphraseFile, flagPassphraseEnv)
 	if err != nil {
 		return err
 	}
@@ -947,7 +960,7 @@ func changePassphrase(c *cli.Context) error {
 	}
 	mkFile := filepath.Join(flagDatabase, "master.key")
 
-	oldPass, err := crypto.Passphrase(flagPassphraseCmd, flagPassphraseFile)
+	oldPass, err := crypto.Passphrase(flagPassphraseCmd, flagPassphraseFile, flagPassphraseEnv)
 	if err != nil {
 		return err
 	}
@@ -957,7 +970,7 @@ func changePassphrase(c *cli.Context) error {
 	}
 	defer mk.Wipe()
 
-	newPass, err := crypto.NewPassphrase(c.String("new-passphrase-command"), c.String("new-passphrase-file"))
+	newPass, err := crypto.NewPassphrase(c.String("new-passphrase-command"), c.String("new-passphrase-file"), c.String("new-passphrase-env"))
 	if err != nil {
 		return err
 	}

--- a/c2FmZQ/c2FmZQ-server/main.go
+++ b/c2FmZQ/c2FmZQ-server/main.go
@@ -36,6 +36,7 @@ var (
 	flagEncryptMetadata       bool
 	flagPassphraseFile        string
 	flagPassphraseCmd         string
+	flagPassphraseEnv         string
 	flagHTDigestFile          string
 	flagAutocertDomain        string
 	flagAutocertAddr          string
@@ -148,6 +149,13 @@ func main() {
 				Destination: &flagPassphraseFile,
 			},
 			&cli.StringFlag{
+				Name:        "passphrase-env",
+				Value:       "",
+				Usage:       "Use value of `ENV` as database passphrase.",
+				EnvVars:     []string{"C2FMZQ_PASSPHRASE_ENV"},
+				Destination: &flagPassphraseEnv,
+			},
+			&cli.StringFlag{
 				Name:        "htdigest-file",
 				Value:       "",
 				Usage:       "The name of the htdigest `FILE` to use for basic auth for some endpoints, e.g. /metrics",
@@ -188,7 +196,7 @@ func startServer(c *cli.Context) error {
 	var pp []byte
 	if flagEncryptMetadata {
 		var err error
-		if pp, err = crypto.Passphrase(flagPassphraseCmd, flagPassphraseFile); err != nil {
+		if pp, err = crypto.Passphrase(flagPassphraseCmd, flagPassphraseFile, flagPassphraseEnv); err != nil {
 			return err
 		}
 	}

--- a/c2FmZQ/internal/crypto/passphrase.go
+++ b/c2FmZQ/internal/crypto/passphrase.go
@@ -13,7 +13,10 @@ import (
 // Passphrase retrieves a passphrase. If cmd is set, the passphrase is the
 // output of the command. Or, if file is set, the passphrase is the content
 // of the file. Otherwise, the passphrase is read from the terminal.
-func Passphrase(cmd, file string) ([]byte, error) {
+func Passphrase(cmd, file, env string) ([]byte, error) {
+	if env != "" {
+		return []byte(env), nil
+	}
 	if cmd != "" {
 		c := exec.Command("/bin/sh", "-c", cmd)
 		c.Stderr = os.Stderr
@@ -30,7 +33,10 @@ func Passphrase(cmd, file string) ([]byte, error) {
 
 // NewPassphrase is like Passphrase but will prompt for a 'new' passphrase twice
 // if it is coming from a terminal.
-func NewPassphrase(cmd, file string) ([]byte, error) {
+func NewPassphrase(cmd, file, env string) ([]byte, error) {
+	if env != "" {
+		return []byte(env), nil
+	}
 	if cmd != "" {
 		c := exec.Command("/bin/sh", "-c", cmd)
 		c.Stderr = os.Stderr


### PR DESCRIPTION
Support server passphrase provided by environment variable C2FMZQ_PASSPHRASE_ENV.

I think might be useful for use with docker usage.

_Note: Sorry for the prior PR, mixed up commit author before..._
