### PR TITLE
Add blob: in media-src

### DIFF
--- a/c2FmZQ/internal/pwa/index.html
+++ b/c2FmZQ/internal/pwa/index.html
@@ -20,7 +20,7 @@ c2FmZQ. If not, see <https://www.gnu.org/licenses/>.
 <head>
 <title>Login</title>
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-<meta http-equiv="content-security-policy" content="default-src 'self'; img-src 'self' data:; style-src 'unsafe-inline' 'self'; form-action 'none';" />
+<meta http-equiv="content-security-policy" content="default-src 'self'; img-src 'self' data:; media-src 'self' blob:; style-src 'unsafe-inline' 'self'; form-action 'none';" />
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
 <link rel="icon" type="image/png" href="c2.png" />
 <link rel="stylesheet" type="text/css" href="style.css" />


### PR DESCRIPTION
The content-security-policy needs to allow `blob:` as media-src.

Fixes: https://github.com/c2FmZQ/c2FmZQ/issues/49