### PR TITLE
Fall back to generic thumbnail when format is unsupported

### DIFF
--- a/c2FmZQ/internal/pwa/ui.js
+++ b/c2FmZQ/internal/pwa/ui.js
@@ -2764,10 +2764,11 @@ class UI {
         reader.readAsDataURL(file);
       });
     } else if (file.type.startsWith('video/')) {
-      return new Promise(resolve => {
+      return new Promise((resolve, reject) => {
         const video = document.createElement('video');
         video.muted = true;
         video.src = URL.createObjectURL(file);
+        video.addEventListener('error', reject);
         video.addEventListener('loadeddata', () => {
           setTimeout(() => {
             video.currentTime = Math.floor(Math.min(video.duration/2, 5));

--- a/c2FmZQ/internal/pwa/version.js
+++ b/c2FmZQ/internal/pwa/version.js
@@ -18,7 +18,7 @@
 
 'use strict';
 
-const VERSION = 'v0.4.12';
+const VERSION = 'v0.4.13';
 
 // Indicates that the PWA is only allowed to connect to the server from which
 // it was loaded. Set to false to allow cross-origin connections.


### PR DESCRIPTION
When generating a thumbnail for a video file, fall back to a generic (text only) thumbnail when the file format isn't supported by the browser.

This should address is remaining part of https://github.com/c2FmZQ/c2FmZQ/issues/49